### PR TITLE
Bug fixes to enable loading configuration from (Python) file

### DIFF
--- a/atilla/server.py
+++ b/atilla/server.py
@@ -95,7 +95,7 @@ def create_app(name, mode, app_class=None, config=None, settings_module=None):
             u'{0}.{1}'.format(settings_module, config_name)
         )
         if config and os.path.exists(config):
-            app.config.from_file(config)
+            app.config.from_pyfile(config)
     except ImportError:
             raise RuntimeError(u"Can't find {0} in {1}".format(config_name, settings_module))
 

--- a/atilla/server.py
+++ b/atilla/server.py
@@ -94,7 +94,7 @@ def create_app(name, mode, app_class=None, config=None, settings_module=None):
         app.config.from_object(
             u'{0}.{1}'.format(settings_module, config_name)
         )
-        if config and os.path.exist(config):
+        if config and os.path.exists(config):
             app.config.from_file(config)
     except ImportError:
             raise RuntimeError(u"Can't find {0} in {1}".format(config_name, settings_module))


### PR DESCRIPTION
Right now if a `config` argument is given to `atilla.server.create_app()` it will/can blow up in two different ways:

1. The reference to `os.path.exist()` will trigger an `AttributeError`.
2. The reference to `app.config.from_file()` will also trigger an `AttributeError`.

The first case is clearly a typo intended to be `os.path.exists()` (trivial to fix). For the second case, right now it will just blow up. In this pull request I've assumed that `app.config.from_pyfile()` was intended, because this seems like the only sane choice:

```python
>>> import flask
>>> flask.__version__
'0.10.1'
>>> app = flask.Flask('whatever')
>>> [n for n in dir(app.config) if n.startswith('from_')]
['from_envvar', 'from_object', 'from_pyfile']
```